### PR TITLE
Implement an allocator that can reuse allocated chunks.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "thirdparty/gtest"]
-	path = thirdparty/gtest
-	url = https://github.com/google/googletest.git

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -2092,7 +2092,7 @@ typedef GenericValue<UTF8<> > Value;
     \tparam StackAllocator Allocator for allocating memory for stack during parsing.
     \warning Although GenericDocument inherits from GenericValue, the API does \b not provide any virtual functions, especially no virtual destructor.  To avoid memory leaks, do not \c delete a GenericDocument object via a pointer to a GenericValue.
 */
-template <typename Encoding, typename Allocator = MemoryPoolAllocator<>, typename StackAllocator = CrtAllocator>
+template <typename Encoding, typename Allocator = MemoryPoolAllocator<>, typename StackAllocator = MemoryPoolAllocator<> >
 class GenericDocument : public GenericValue<Encoding, Allocator> {
 public:
     typedef typename Encoding::Ch Ch;                       //!< Character type derived from Encoding.

--- a/include/rapidjson/fwd.h
+++ b/include/rapidjson/fwd.h
@@ -58,7 +58,7 @@ typedef GenericInsituStringStream<UTF8<char> > InsituStringStream;
 template <typename Encoding, typename Allocator>
 class GenericStringBuffer;
 
-typedef GenericStringBuffer<UTF8<char>, CrtAllocator> StringBuffer;
+typedef GenericStringBuffer<UTF8<char>, MemoryPoolAllocator<CrtAllocator> > StringBuffer;
 
 // filereadstream.h
 
@@ -73,7 +73,7 @@ class FileWriteStream;
 template <typename Allocator>
 struct GenericMemoryBuffer;
 
-typedef GenericMemoryBuffer<CrtAllocator> MemoryBuffer;
+typedef GenericMemoryBuffer<MemoryPoolAllocator<CrtAllocator> > MemoryBuffer;
 
 // memorystream.h
 
@@ -87,7 +87,7 @@ struct BaseReaderHandler;
 template <typename SourceEncoding, typename TargetEncoding, typename StackAllocator>
 class GenericReader;
 
-typedef GenericReader<UTF8<char>, UTF8<char>, CrtAllocator> Reader;
+typedef GenericReader<UTF8<char>, UTF8<char>, MemoryPoolAllocator<CrtAllocator> > Reader;
 
 // writer.h
 
@@ -118,14 +118,14 @@ typedef GenericValue<UTF8<char>, MemoryPoolAllocator<CrtAllocator> > Value;
 template <typename Encoding, typename Allocator, typename StackAllocator>
 class GenericDocument;
 
-typedef GenericDocument<UTF8<char>, MemoryPoolAllocator<CrtAllocator>, CrtAllocator> Document;
+typedef GenericDocument<UTF8<char>, MemoryPoolAllocator<CrtAllocator>, MemoryPoolAllocator<CrtAllocator> > Document;
 
 // pointer.h
 
 template <typename ValueType, typename Allocator>
 class GenericPointer;
 
-typedef GenericPointer<Value, CrtAllocator> Pointer;
+typedef GenericPointer<Value, MemoryPoolAllocator<CrtAllocator> > Pointer;
 
 // schema.h
 
@@ -135,7 +135,7 @@ class IGenericRemoteSchemaDocumentProvider;
 template <typename ValueT, typename Allocator>
 class GenericSchemaDocument;
 
-typedef GenericSchemaDocument<Value, CrtAllocator> SchemaDocument;
+typedef GenericSchemaDocument<Value, MemoryPoolAllocator<CrtAllocator> > SchemaDocument;
 typedef IGenericRemoteSchemaDocumentProvider<SchemaDocument> IRemoteSchemaDocumentProvider;
 
 template <
@@ -144,7 +144,7 @@ template <
     typename StateAllocator>
 class GenericSchemaValidator;
 
-typedef GenericSchemaValidator<SchemaDocument, BaseReaderHandler<UTF8<char>, void>, CrtAllocator> SchemaValidator;
+typedef GenericSchemaValidator<SchemaDocument, BaseReaderHandler<UTF8<char>, void>, MemoryPoolAllocator<CrtAllocator> > SchemaValidator;
 
 RAPIDJSON_NAMESPACE_END
 

--- a/include/rapidjson/internal/regex.h
+++ b/include/rapidjson/internal/regex.h
@@ -112,7 +112,7 @@ class GenericRegexSearch;
         Cox, Russ. "Regular Expression Matching Can Be Simple And Fast (but is slow in Java, Perl, PHP, Python, Ruby,...).", 
         https://swtch.com/~rsc/regexp/regexp1.html 
 */
-template <typename Encoding, typename Allocator = CrtAllocator>
+template <typename Encoding, typename Allocator = MemoryPoolAllocator<> >
 class GenericRegex {
 public:
     typedef Encoding EncodingType;
@@ -597,7 +597,7 @@ private:
     bool anchorEnd_;
 };
 
-template <typename RegexType, typename Allocator = CrtAllocator>
+template <typename RegexType, typename Allocator = MemoryPoolAllocator<> >
 class GenericRegexSearch {
 public:
     typedef typename RegexType::EncodingType Encoding;

--- a/include/rapidjson/memorybuffer.h
+++ b/include/rapidjson/memorybuffer.h
@@ -33,7 +33,7 @@ RAPIDJSON_NAMESPACE_BEGIN
     \tparam Allocator type for allocating memory buffer.
     \note implements Stream concept
 */
-template <typename Allocator = CrtAllocator>
+template <typename Allocator = MemoryPoolAllocator<> >
 struct GenericMemoryBuffer {
     typedef char Ch; // byte
 

--- a/include/rapidjson/pointer.h
+++ b/include/rapidjson/pointer.h
@@ -77,7 +77,7 @@ enum PointerParseErrorCode {
     \note GenericPointer uses same encoding of ValueType.
     However, Allocator of GenericPointer is independent of Allocator of Value.
 */
-template <typename ValueType, typename Allocator = CrtAllocator>
+template <typename ValueType, typename Allocator = MemoryPoolAllocator<> >
 class GenericPointer {
 public:
     typedef typename ValueType::EncodingType EncodingType;  //!< Encoding type from Value

--- a/include/rapidjson/prettywriter.h
+++ b/include/rapidjson/prettywriter.h
@@ -44,7 +44,7 @@ enum PrettyFormatOptions {
     \tparam TargetEncoding Encoding of output stream.
     \tparam StackAllocator Type of allocator for allocating memory of stack.
 */
-template<typename OutputStream, typename SourceEncoding = UTF8<>, typename TargetEncoding = UTF8<>, typename StackAllocator = CrtAllocator, unsigned writeFlags = kWriteDefaultFlags>
+template<typename OutputStream, typename SourceEncoding = UTF8<>, typename TargetEncoding = UTF8<>, typename StackAllocator = MemoryPoolAllocator<>, unsigned writeFlags = kWriteDefaultFlags>
 class PrettyWriter : public Writer<OutputStream, SourceEncoding, TargetEncoding, StackAllocator, writeFlags> {
 public:
     typedef Writer<OutputStream, SourceEncoding, TargetEncoding, StackAllocator, writeFlags> Base;

--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -535,7 +535,7 @@ template<> inline void SkipWhitespace(EncodedInputStream<UTF8<>, MemoryStream>& 
     \tparam TargetEncoding Encoding of the parse output.
     \tparam StackAllocator Allocator type for stack.
 */
-template <typename SourceEncoding, typename TargetEncoding, typename StackAllocator = CrtAllocator>
+template <typename SourceEncoding, typename TargetEncoding, typename StackAllocator = MemoryPoolAllocator<> >
 class GenericReader {
 public:
     typedef typename SourceEncoding::Ch Ch; //!< SourceEncoding character type

--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -1315,7 +1315,7 @@ public:
     \tparam ValueT Type of JSON value (e.g. \c Value ), which also determine the encoding.
     \tparam Allocator Allocator type for allocating memory of this document.
 */
-template <typename ValueT, typename Allocator = CrtAllocator>
+template <typename ValueT, typename Allocator = MemoryPoolAllocator<> >
 class GenericSchemaDocument {
 public:
     typedef ValueT ValueType;
@@ -1565,7 +1565,7 @@ typedef IGenericRemoteSchemaDocumentProvider<SchemaDocument> IRemoteSchemaDocume
 template <
     typename SchemaDocumentType,
     typename OutputHandler = BaseReaderHandler<typename SchemaDocumentType::SchemaType::EncodingType>,
-    typename StateAllocator = CrtAllocator>
+    typename StateAllocator = MemoryPoolAllocator<> >
 class GenericSchemaValidator :
     public internal::ISchemaStateFactory<typename SchemaDocumentType::SchemaType>, 
     public internal::ISchemaValidator
@@ -1960,7 +1960,7 @@ template <
     typename InputStream,
     typename SourceEncoding,
     typename SchemaDocumentType = SchemaDocument,
-    typename StackAllocator = CrtAllocator>
+    typename StackAllocator = MemoryPoolAllocator<> >
 class SchemaValidatingReader {
 public:
     typedef typename SchemaDocumentType::PointerType PointerType;

--- a/include/rapidjson/stringbuffer.h
+++ b/include/rapidjson/stringbuffer.h
@@ -37,7 +37,7 @@ RAPIDJSON_NAMESPACE_BEGIN
     \tparam Allocator type for allocating memory buffer.
     \note implements Stream concept
 */
-template <typename Encoding, typename Allocator = CrtAllocator>
+template <typename Encoding, typename Allocator = MemoryPoolAllocator<> >
 class GenericStringBuffer {
 public:
     typedef typename Encoding::Ch Ch;

--- a/include/rapidjson/writer.h
+++ b/include/rapidjson/writer.h
@@ -87,7 +87,7 @@ enum WriteFlag {
     \tparam StackAllocator Type of allocator for allocating memory of stack.
     \note implements Handler concept
 */
-template<typename OutputStream, typename SourceEncoding = UTF8<>, typename TargetEncoding = UTF8<>, typename StackAllocator = CrtAllocator, unsigned writeFlags = kWriteDefaultFlags>
+template<typename OutputStream, typename SourceEncoding = UTF8<>, typename TargetEncoding = UTF8<>, typename StackAllocator = MemoryPoolAllocator<>, unsigned writeFlags = kWriteDefaultFlags>
 class Writer {
 public:
     typedef typename SourceEncoding::Ch Ch;


### PR DESCRIPTION
Improve the memory pool allocator to reuse its allocated chunks.

1. keep chunks in a doubly linked list
2. on `Clear()`, set size to 0 for all chunks
3. when allocating space, reuse previously allocated chunk
4. when allocating larger space than previous chunks, find or allocate next available chunk and reorder the doubly linked list to reduce waste (I assume this rarely rarely happens, default chunk size is 64kB)

Assumption: `Malloc()` requested size is smaller than default chunk size in majority of cases.