### PR TITLE
Add replace null characters flag to reader and writer

### DIFF
--- a/include/rapidjson/encodings.h
+++ b/include/rapidjson/encodings.h
@@ -83,6 +83,10 @@ concept Encoding {
 \endcode
 */
 
+// Forward declaration.
+template<typename Stream>
+inline void PutUnsafe(Stream& stream, typename Stream::Ch c);
+
 ///////////////////////////////////////////////////////////////////////////////
 // UTF8
 
@@ -681,10 +685,6 @@ struct Transcoder {
         return Transcode(is, os);   // Since source/target encoding is different, must transcode.
     }
 };
-
-// Forward declaration.
-template<typename Stream>
-inline void PutUnsafe(Stream& stream, typename Stream::Ch c);
 
 //! Specialization of Transcoder with same source and target encoding.
 template<typename Encoding>


### PR DESCRIPTION
This is a patch to allow rapidjson generating json strings without null characters, if a null character exists in the document.

This is because postgresql database doesn't support jsonb content that contains null characters.

Aligns the behavior with backend so the content can be interoped between two processes.