### PR TITLE
Include missing key value in assert message

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "thirdparty/gtest"]
-	path = thirdparty/gtest
-	url = https://github.com/google/googletest.git

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -1108,7 +1108,15 @@ public:
         if (member != MemberEnd())
             return member->value;
         else {
-            RAPIDJSON_ASSERT(false);    // see above note
+#ifdef RAPIDJSON_ASSERT_MSG
+            static const char* const ASSERT_MESSAGE = "cannot find member %s";
+            const size_t assertBufferSize = strlen(ASSERT_MESSAGE) + name.GetStringLength() + 1;
+            char assertBuffer[assertBufferSize];
+            snprintf(assertBuffer, assertBufferSize, ASSERT_MESSAGE, name.GetString());
+            RAPIDJSON_ASSERT_MSG(false, assertBuffer); // see above note
+#else
+            RAPIDJSON_ASSERT(false); // see above note
+#endif
 
             // This will generate -Wexit-time-destructors in clang
             // static GenericValue NullValue;

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -1109,7 +1109,7 @@ public:
             return member->value;
         else {
 #ifdef RAPIDJSON_ASSERT_MSG
-            static const char* const ASSERT_MESSAGE = "cannot find member %s";
+            static const char* const ASSERT_MESSAGE = "cannot find member '%s'";
             const size_t assertBufferSize = strlen(ASSERT_MESSAGE) + name.GetStringLength() + 1;
             char assertBuffer[assertBufferSize];
             snprintf(assertBuffer, assertBufferSize, ASSERT_MESSAGE, name.GetString());


### PR DESCRIPTION
This adds the macro `RAPIDJSON_ASSERT_MSG`, which by default proxies back to the base `RAPIDJSON_ASSERT`. 

With the `cassert` backend it only works for _literal_ messages, since `cassert` relies on macro stringification, but by overriding it to use `BOOST_ASSERT_MSG` it's possible to use dynamic messages. 

To take advantage of the new behaviour, callers should add 
```
add_definitions("-DRAPIDJSON_ASSERT_MSG=BOOST_ASSERT_MSG")
```